### PR TITLE
feat: add TestDescriptor filters capabilities to runtime

### DIFF
--- a/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/TckRuntime.java
+++ b/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/TckRuntime.java
@@ -17,7 +17,7 @@ package org.eclipse.dataspacetck.runtime;
 import org.eclipse.dataspacetck.core.spi.boot.Monitor;
 import org.eclipse.dataspacetck.core.spi.system.SystemLauncher;
 import org.eclipse.dataspacetck.core.system.ConsoleMonitor;
-import org.junit.platform.engine.FilterResult;
+import org.eclipse.dataspacetck.runtime.filter.DisplayNameFilter;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.store.Namespace;
 import org.junit.platform.launcher.LauncherSession;
@@ -30,6 +30,7 @@ import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,9 @@ public class TckRuntime {
     private final Map<String, String> properties = new HashMap<>();
     private Monitor monitor;
     private Class<? extends SystemLauncher> launcher;
+    @Deprecated(since = "1.0.1")
     private Predicate<String> displayNameMatching;
+    private final List<PostDiscoveryFilter> filters = new ArrayList<>();
 
     private TckRuntime() {
     }
@@ -72,10 +75,10 @@ public class TckRuntime {
 
 
         if (displayNameMatching != null) {
-            requestBuilder.filters((PostDiscoveryFilter) descriptor -> displayNameMatching.test(descriptor.getDisplayName())
-                    ? FilterResult.included("Matches display name")
-                    : FilterResult.excluded("Does not match display name"));
+            filters.add(DisplayNameFilter.includeName(displayNameMatching));
         }
+
+        filters.forEach(requestBuilder::filters);
 
         var request = requestBuilder.build();
         var launcherConfig = LauncherConfig.builder()
@@ -132,12 +135,25 @@ public class TckRuntime {
         }
 
         /**
+         * Add all supplied post discovery filters to the runtime.
+         *
+         * @param filters the filters.
+         * @return the builder.
+         */
+        public Builder filters(PostDiscoveryFilter... filters) {
+            runtime.filters.addAll(Arrays.stream(filters).toList());
+            return this;
+        }
+
+        /**
          * Permit to filter tests by the content of @DisplayName annotation. If the predicate matches the test is included,
          * excluded otherwise.
          *
          * @param displayNameMatching the predicate.
          * @return the builder.
+         * @deprecated please use {@link #filters} with {@link org.eclipse.dataspacetck.runtime.filter.DisplayNameFilter#includeName(Predicate)}
          */
+        @Deprecated(since = "1.0.0")
         public Builder displayNameMatching(Predicate<String> displayNameMatching) {
             runtime.displayNameMatching = displayNameMatching;
             return this;
@@ -153,7 +169,6 @@ public class TckRuntime {
 
             return runtime;
         }
-
     }
 
     private static class StoreMonitorSessionListener implements LauncherSessionListener {

--- a/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/filter/DisplayNameFilter.java
+++ b/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/filter/DisplayNameFilter.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspacetck.runtime.filter;
+
+import org.junit.platform.launcher.PostDiscoveryFilter;
+
+import java.util.function.Predicate;
+
+import static org.junit.platform.engine.FilterResult.includedIf;
+
+public class DisplayNameFilter {
+
+    /**
+     * Includes tests which display name matched the passing predicate.
+     *
+     * @param predicate the predicate
+     * @return the filter.
+     */
+    public static PostDiscoveryFilter includeName(Predicate<String> predicate) {
+        return descriptor -> includedIf(
+                predicate.test(descriptor.getDisplayName()),
+                () -> "Matches display name",
+                () -> "Does not match display name"
+        );
+    }
+
+}

--- a/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/TckRuntimeTest.java
+++ b/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/TckRuntimeTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_LAUNCHER;
+import static org.eclipse.dataspacetck.runtime.filter.DisplayNameFilter.includeName;
 
 public class TckRuntimeTest {
 
@@ -88,7 +89,22 @@ public class TckRuntimeTest {
     }
 
     @Test
-    void canFilterByTestName() {
+    void canFilterByTestName_whenUsingFilter() {
+        var runtime = TckRuntime.Builder.newInstance()
+                .launcher(TestSystemLauncher.class)
+                .addPackage("org.eclipse.dataspacetck.runtime.test")
+                .filters(includeName(displayName -> displayName.equals("FILTER")))
+                .build();
+
+        var summary = runtime.execute();
+
+        assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
+        assertThat(summary.getTestsFoundCount()).isEqualTo(1);
+    }
+
+    @Deprecated(since = "1.0.0")
+    @Test
+    void canFilterByTestName_deprecated() {
         var runtime = TckRuntime.Builder.newInstance()
                 .launcher(TestSystemLauncher.class)
                 .addPackage("org.eclipse.dataspacetck.runtime.test")


### PR DESCRIPTION
## What this PR changes/adds

Permit to define `PostDiscoveryFilter`s on TckRuntime, like filters based on test name or tags.

## Why it does that

flexibility

## Further notes
- deprecated the `displayNameMatches` method

## Linked Issue(s)

Closes #99

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
