### PR TITLE
feat: add tags include/exclude config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Technology Compatibility Kit Commons
 
 Shared code that is used by the Technology Compatibility Kits and the build plugins alike.
+
+## TckRuntime Configuration
+
+`TckRuntime` accepts configuration properties via the `Builder#property(key, value)` or `Builder#properties(map)` methods. These properties are also read from Java system properties (or environment variables as fallback).
+
+### Configuration Properties
+
+| Property | Default | Description |
+|---|---|---|
+| `dataspacetck.launcher` | — | Fully-qualified class name of the `SystemLauncher` implementation to use. Required unless set via `Builder#launcher(Class)`. |
+| `dataspacetck.callback.address` | `http://localhost:8083` | Callback address advertised to the system under test. |
+| `dataspacetck.host` | `0.0.0.0` | Host on which the TCK callback listener binds. |
+| `dataspacetck.port` | `8083` | Port on which the TCK callback listener binds. |
+| `dataspacetck.debug` | `false` | Enable debug-level console output. |
+| `dataspacetck.ansi` | `true` | Enable ANSI color codes in console output. |
+| `dataspacetck.filters.tags.include` | — | Comma-separated list of JUnit 5 tags. Only tests carrying at least one of these tags are executed. |
+| `dataspacetck.filters.tags.exclude` | — | Comma-separated list of JUnit 5 tags. Tests carrying any of these tags are skipped. |
+
+### Example
+
+```java
+var summary = TckRuntime.Builder.newInstance()
+        .launcher(MySystemLauncher.class)
+        .addPackage("com.example.tck.tests")
+        .property("dataspacetck.callback.address", "http://my-host:9090")
+        .property("dataspacetck.filters.tags.include", "mandatory,core")
+        .property("dataspacetck.filters.tags.exclude", "experimental")
+        .build()
+        .execute();
+```
+
+When both include and exclude filters are set, the include filter is applied first and the exclude filter is applied to the remaining tests.

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/system/SystemsConstants.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/system/SystemsConstants.java
@@ -26,4 +26,7 @@ public interface SystemsConstants {
     String TCK_DEFAULT_HOST = "0.0.0.0";
     int TCK_DEFAULT_PORT = 8083;
     String TCK_LAUNCHER = TCK_PREFIX + ".launcher";
+
+    String TCK_FILTERS_TAGS_INCLUDE = TCK_PREFIX + ".filters.tags.include";
+    String TCK_FILTERS_TAGS_EXCLUDE = TCK_PREFIX + ".filters.tags.exclude";
 }

--- a/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/TckRuntime.java
+++ b/runtimes/tck-runtime/src/main/java/org/eclipse/dataspacetck/runtime/TckRuntime.java
@@ -18,11 +18,14 @@ import org.eclipse.dataspacetck.core.spi.boot.Monitor;
 import org.eclipse.dataspacetck.core.spi.system.SystemLauncher;
 import org.eclipse.dataspacetck.core.system.ConsoleMonitor;
 import org.eclipse.dataspacetck.runtime.filter.DisplayNameFilter;
+import org.jspecify.annotations.NonNull;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.store.Namespace;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.LauncherSession;
 import org.junit.platform.launcher.LauncherSessionListener;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TagFilter;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
@@ -37,6 +40,8 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import static java.lang.Boolean.parseBoolean;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_FILTERS_TAGS_EXCLUDE;
+import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_FILTERS_TAGS_INCLUDE;
 import static org.eclipse.dataspacetck.core.api.system.SystemsConstants.TCK_LAUNCHER;
 import static org.eclipse.dataspacetck.core.system.ConfigFunctions.propertyOrEnv;
 import static org.eclipse.dataspacetck.core.system.ConsoleMonitor.ANSI_PROPERTY;
@@ -69,18 +74,7 @@ public class TckRuntime {
 
         var summaryListener = new SummaryGeneratingListener();
 
-        var requestBuilder = LauncherDiscoveryRequestBuilder.request()
-                .filters(includeClassNamePatterns(TEST_POSTFIX))
-                .selectors(packages.stream().map(DiscoverySelectors::selectPackage).toList());
-
-
-        if (displayNameMatching != null) {
-            filters.add(DisplayNameFilter.includeName(displayNameMatching));
-        }
-
-        filters.forEach(requestBuilder::filters);
-
-        var request = requestBuilder.build();
+        var request = createLauncherDiscoveryRequest();
         var launcherConfig = LauncherConfig.builder()
                 .addLauncherSessionListeners(new StoreMonitorSessionListener(monitor))
                 .build();
@@ -96,6 +90,31 @@ public class TckRuntime {
             fail("No TCK tests found");
         }
         return summary;
+    }
+
+    private @NonNull LauncherDiscoveryRequest createLauncherDiscoveryRequest() {
+        var requestBuilder = LauncherDiscoveryRequestBuilder.request()
+                .filters(includeClassNamePatterns(TEST_POSTFIX))
+                .selectors(packages.stream().map(DiscoverySelectors::selectPackage).toList());
+
+
+        if (properties.containsKey(TCK_FILTERS_TAGS_INCLUDE)) {
+            var includeTags = properties.get(TCK_FILTERS_TAGS_INCLUDE);
+            requestBuilder.filters(TagFilter.includeTags(includeTags.split(",")));
+        }
+
+        if (properties.containsKey(TCK_FILTERS_TAGS_EXCLUDE)) {
+            var excludeTags = properties.get(TCK_FILTERS_TAGS_EXCLUDE);
+            requestBuilder.filters(TagFilter.excludeTags(excludeTags.split(",")));
+        }
+
+        if (displayNameMatching != null) {
+            requestBuilder.filters(DisplayNameFilter.includeName(displayNameMatching));
+        }
+
+        filters.forEach(requestBuilder::filters);
+
+        return requestBuilder.build();
     }
 
     public static class Builder {

--- a/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/TckRuntimeTest.java
+++ b/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/TckRuntimeTest.java
@@ -18,6 +18,7 @@ import org.eclipse.dataspacetck.core.spi.system.SystemConfiguration;
 import org.eclipse.dataspacetck.core.spi.system.SystemLauncher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,34 +89,70 @@ public class TckRuntimeTest {
         });
     }
 
-    @Test
-    void canFilterByTestName_whenUsingFilter() {
-        var runtime = TckRuntime.Builder.newInstance()
-                .launcher(TestSystemLauncher.class)
-                .addPackage("org.eclipse.dataspacetck.runtime.test")
-                .filters(includeName(displayName -> displayName.equals("FILTER")))
-                .build();
+    @Nested
+    class Filters {
+        @Test
+        void canFilterByTestName_whenUsingFilter() {
+            var runtime = TckRuntime.Builder.newInstance()
+                    .launcher(TestSystemLauncher.class)
+                    .addPackage("org.eclipse.dataspacetck.runtime.test")
+                    .filters(includeName(displayName -> displayName.equals("FILTER")))
+                    .build();
 
-        var summary = runtime.execute();
+            var summary = runtime.execute();
 
-        assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
-        assertThat(summary.getTestsFoundCount()).isEqualTo(1);
+            assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
+            assertThat(summary.getTestsFoundCount()).isEqualTo(1);
+        }
+
+        @Test
+        void canFilterByTestTagInclude_whenUsingProperties() {
+            var runtime = TckRuntime.Builder.newInstance()
+                    .property("dataspacetck.filters.tags.include", "filter,anothertag")
+                    .launcher(TestSystemLauncher.class)
+                    .addPackage("org.eclipse.dataspacetck.runtime.test")
+                    .build();
+
+            var summary = runtime.execute();
+
+            assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
+            assertThat(summary.getTestsFoundCount()).isEqualTo(1);
+        }
+
+        @Test
+        void canFilterByTestTagExclude_whenUsingProperties() {
+            var allTests = TckRuntime.Builder.newInstance()
+                    .launcher(TestSystemLauncher.class)
+                    .addPackage("org.eclipse.dataspacetck.runtime.test")
+                    .build().execute().getTestsFoundCount();
+
+            var filteredTests = TckRuntime.Builder.newInstance()
+                    .property("dataspacetck.filters.tags.exclude", "filter,anothertag")
+                    .launcher(TestSystemLauncher.class)
+                    .addPackage("org.eclipse.dataspacetck.runtime.test")
+                    .build()
+                    .execute();
+
+            assertThat(filteredTests.getTestsFoundCount()).isEqualTo(allTests - 1);
+        }
+
+        @Deprecated(since = "1.0.0")
+        @Test
+        void canFilterByTestName_deprecated() {
+            var runtime = TckRuntime.Builder.newInstance()
+                    .launcher(TestSystemLauncher.class)
+                    .addPackage("org.eclipse.dataspacetck.runtime.test")
+                    .displayNameMatching(displayName -> displayName.equals("FILTER"))
+                    .build();
+
+            var summary = runtime.execute();
+
+            assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
+            assertThat(summary.getTestsFoundCount()).isEqualTo(1);
+        }
     }
 
-    @Deprecated(since = "1.0.0")
-    @Test
-    void canFilterByTestName_deprecated() {
-        var runtime = TckRuntime.Builder.newInstance()
-                .launcher(TestSystemLauncher.class)
-                .addPackage("org.eclipse.dataspacetck.runtime.test")
-                .displayNameMatching(displayName -> displayName.equals("FILTER"))
-                .build();
 
-        var summary = runtime.execute();
-
-        assertThat(summary.getTestsSucceededCount()).isEqualTo(1);
-        assertThat(summary.getTestsFoundCount()).isEqualTo(1);
-    }
 
     public static class TestSystemLauncher implements SystemLauncher {
 

--- a/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/test/DummyTest.java
+++ b/runtimes/tck-runtime/src/test/java/org/eclipse/dataspacetck/runtime/test/DummyTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspacetck.runtime.test;
 
 import org.eclipse.dataspacetck.core.system.SystemBootstrapExtension;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,7 @@ public class DummyTest {
     }
 
     @Test
+    @Tag("filter")
     @DisplayName("FILTER")
     void anotherTest() {
         // this test exists to show how it can be possible to filter tests by display name content


### PR DESCRIPTION
## What this PR changes/adds

Make junit tag filters enableabe by setting properties:
`dataspacetck.filters.tags.include` and `dataspacetck.filters.tags.exclude`

## Why it does that

enable test filtering by tags

## Further notes
- add some documentation

## Linked Issue(s)

Closes #101 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
