### PR TITLE
build: add necessary plugin validation explicit dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,11 @@ allprojects {
                 sign(publishing.publications)
             }
         }
+
+        // FIXME - workaround for https://github.com/gradle/gradle/issues/26091
+        tasks.withType<AbstractPublishToMaven>().configureEach {
+            dependsOn(tasks.withType<Sign>())
+        }
     }
 
 


### PR DESCRIPTION
## What this PR changes/adds

As it is currently broken https://github.com/eclipse-dataspacetck/tck-common/actions/workflows/trigger_snapshot.yml
This workaround had been set also in the tck-build project.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
