### PR TITLE
build: new publish mechanism

### DIFF
--- a/.github/actions/publish-maven-artifacts/action.yml
+++ b/.github/actions/publish-maven-artifacts/action.yml
@@ -16,9 +16,6 @@ name: "Publish Maven Artifacts"
 description: "Build and publish maven artifacts to repository"
 
 inputs:
-  version:
-    description: the version to be attached to the artifacts, if not specified, the one configured in the project will be used
-    required: false
   gpg-private-key:
     description: the gpg private key used to publish
     required: true
@@ -41,24 +38,14 @@ runs:
       with:
         gpg-private-key: ${{ inputs.gpg-private-key }}
 
-    - if: inputs.version != null
-      shell: bash
-      run: |
-        sed -i 's#^version=.*#version=${{ inputs.version }}#g' $(find . -name "gradle.properties")
-
-    - name: "Publish To MavenCentral"
+    - name: Publish to maven central
       shell: bash
       env:
-        CENTRAL_SONATYPE_TOKEN_USERNAME: ${{ inputs.maven-username }}
-        CENTRAL_SONATYPE_TOKEN_PASSWORD: ${{ inputs.maven-password }}
-      run: |-
-        VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
-        cmd=""
-        if [[ $VERSION != *-SNAPSHOT ]]
-        then
-          cmd="closeAndReleaseSonatypeStagingRepository";
-        fi
-        echo "Publishing Version $VERSION to Sonatype"
-        ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ inputs.gpg-passphrase }}" \
-                -Dorg.gradle.internal.network.retry.max.attempts=5 -Dorg.gradle.internal.network.retry.initial.backOff=5000
- 
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ inputs.username }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ inputs.password }}
+
+        ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ inputs.gpg-private-key }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ inputs.gpg-passphrase }}
+      run: ./gradlew publishToMavenCentral -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ inputs.gpg-passphrase }}"
+
+

--- a/.github/workflows/tck-release.yml
+++ b/.github/workflows/tck-release.yml
@@ -60,7 +60,6 @@ jobs:
           ref: ${{ needs.create-tag.outputs.TAG }} # checkout the tag created in the previous step
       - uses: eclipse-dataspacetck/tck-common/.github/actions/publish-maven-artifacts@main
         with:
-          version: ${{ needs.create-tag.outputs.VERSION }} # explicitly pass the version
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           maven-username: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}


### PR DESCRIPTION
## What this PR changes/adds

once https://github.com/eclipse-dataspacetck/tck-build/pull/80 is merged, updates the publish action to the new plugin

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
