### PR TITLE
build: avoid duplicated tag

### DIFF
--- a/.github/workflows/tck-release.yml
+++ b/.github/workflows/tck-release.yml
@@ -22,10 +22,10 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     outputs:
-      VERSION: ${{ steps.set-version.outputs.VERSION }}
       TAG: ${{ steps.set-tag.outputs.TAG }}
     steps:
       - uses: actions/checkout@v7
+
       - id: set-version
         run: |
           VERSION=$(echo ${{ github.ref_name }} | cut -d '/' -f 2)
@@ -34,6 +34,7 @@ jobs:
       - uses: eclipse-dataspacetck/tck-common/.github/actions/set-project-version@main
         with:
           version: ${{ steps.set-version.outputs.VERSION }}
+
       - shell: bash
         id: set-tag
         run: |
@@ -74,7 +75,7 @@ jobs:
       - uses: actions/checkout@v7
       - run: |
           latest=$(gh release view --json tagName | jq -r '.tagName')
-          version="${{ needs.create-tag.outputs.VERSION }}"
-          gh release create $version $( [[ ! "$version" =~ RC ]] && echo "--latest" ) --generate-notes --notes-start-tag ${latest}
+          tag="${{ needs.create-tag.outputs.TAG }}"
+          gh release create tag $( [[ ! "tag" =~ RC ]] && echo "--latest" ) --generate-notes --notes-start-tag ${latest}
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What this PR changes/adds

Avoid creation of duplicated tag on gh release creation, by passing the actual tag, the one with the leading `v`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #110 

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
